### PR TITLE
D.367172 Updated the code to get the processor architecture in ECE Precheck Tool.

### DIFF
--- a/ece_os_readiness/mor.py
+++ b/ece_os_readiness/mor.py
@@ -713,7 +713,7 @@ def detect_virtualization() -> str:
 
 
 def check_processor() -> str:
-    """Check system processor name.
+    """Check system processor architecture name.
     Args:
     Returns:
         processor name if succeeded. Else, 'Unknown'.
@@ -725,6 +725,14 @@ def check_processor() -> str:
     except BaseException as e:
         log.debug("Tried to get processor name but hit exception: %s", e)
         print(f"{ERROR} hit exception while querying processor name")
+    if not proc_name:
+        try:
+            stdout, stderr, rc = runcmd('uname -m', ignore_exception=True)
+            if rc == 0 and stdout.strip():
+                proc_name = stdout.strip()
+                log.debug("Got proc_name from uname -m: %s", proc_name)
+        except BaseException as e:
+            log.debug("uname -m failed with exception: %s", e)
     log.debug("Got proc_name: %s", proc_name)
     if not proc_name:
         print(f"{ERROR} cannot get the processor name. The tool cannot " +


### PR DESCRIPTION
The function 'platform.processor()' returned empty for RHEL10 system.
Since platform.processor() underlying depends on 'uname -p' ->

```
root@aac-31:~# uname -p
unknown
```

Hence python treats this value as non-informative and normalizes it to an empty string.
Since we did not want to change the overall processor function. I have added in a try-fallback mechanism for getting the architecture type of the Hardware using 'uname -m'.